### PR TITLE
itemstack function enchancements

### DIFF
--- a/src/main/resources/velt.d.ts
+++ b/src/main/resources/velt.d.ts
@@ -181,7 +181,12 @@ interface Server {
 	 * @alias enchantment
 	 */
 	enchant(name: string): any;
-	/**
+    /**
+	 * Get an itemflag from its **Spigot** name. For example, `hide enchants'.
+	 * @param name The itemflag name (eg. `hide attributes`)
+	 */
+	itemflag(name: string): any;
+    /**
 	 * Get an itemstack from the material name and the options.
 	 */
 	itemstack(material: string, opts?: {} | string): any;

--- a/src/main/resources/velt.d.ts
+++ b/src/main/resources/velt.d.ts
@@ -181,12 +181,12 @@ interface Server {
 	 * @alias enchantment
 	 */
 	enchant(name: string): any;
-    /**
+	/**
 	 * Get an itemflag from its **Spigot** name. For example, `hide enchants'.
 	 * @param name The itemflag name (eg. `hide attributes`)
 	 */
 	itemflag(name: string): any;
-    /**
+	/**
 	 * Get an itemstack from the material name and the options.
 	 */
 	itemstack(material: string, opts?: {} | string): any;

--- a/src/main/resources/velt.js
+++ b/src/main/resources/velt.js
@@ -8,7 +8,7 @@ try {
 const { Vector, BlockIterator } = Java.pkg('org.bukkit.util');
 const { Bukkit, ChatColor, Location , Material, World } = Java.pkg('org.bukkit');
 const ProjectileSource = Java.type('org.bukkit.projectiles.ProjectileSource');
-const ItemStack = Java.type('org.bukkit.inventory.ItemStack');
+const { ItemStack, ItemFlag } = Java.pkg('org.bukkit.inventory');
 const PotionEffectType = Java.type('org.bukkit.potion.PotionEffectType');
 const BukkitRunnable = Java.type('org.bukkit.scheduler.BukkitRunnable');
 const { EntityType, Entity, Player, Projectile, LivingEntity } = Java.pkg('org.bukkit.entity');
@@ -112,6 +112,9 @@ let server = {
 	enchantment(name) {
 		return Enchantment[server.unformat(name)];
 	},
+	itemflag(name) {
+		return ItemFlag.valueOf(server.unformat(name));
+	},
 	itemstack(material, opts = {}) {
 		const {
 			count = 1,
@@ -119,7 +122,9 @@ let server = {
 			lore = undefined, 
 			durability = undefined,
 			unbreakable = undefined,
-			enchantments = []
+			custommodeldata = undefined,
+			enchantments = [],
+			itemflags = []
 		} = opts;
 		let item;
 		let meta;
@@ -130,7 +135,7 @@ let server = {
 		} else if (typeof material === 'string') {
 			return server.itemstack(
 				server.material(material), 
-				{ count, name, lore, durability, unbreakable, enchantments }
+				{ count, name, lore, durability, unbreakable, custommodeldata, enchantments, itemflags }
 			);
 		} else {
 			item = new ItemStack(material);
@@ -147,19 +152,29 @@ let server = {
 			} else {
 				loreArray = lore;
 			}
-			
 			meta.setLore(Arrays.asList(loreArray));
 		}
 		if (durability !== undefined) {
-			meta.setDurability(durability);
+			item.setDurability(durability);
 		}
 		if (unbreakable !== undefined) {
 			meta.setUnbreakable(unbreakable);
+		}
+		if (custommodeldata !== undefined) {
+			meta.setCustomModelData(custommodeldata);
 		}
 		for (const enchantment of enchantments) {
 			const type = enchantment.type || enchantment.enchant || enchantment.enchantment;
 			const enchant = typeof type === 'string' ? server.enchant(type) : type;
 			meta.addEnchant(enchant, enchantment.level, true);
+		}
+		if(itemflags.length > 0) {
+			let flags = [];
+			for(const itemflag of itemflags) {
+				const flag = typeof itemflag === 'string' ? server.itemflag(itemflag) : itemflag;
+				flags.push(flag);
+			}
+			meta.addItemFlags(...flags);
 		}
 		item.setItemMeta(meta);
 		return item;

--- a/src/main/resources/velt.js
+++ b/src/main/resources/velt.js
@@ -141,6 +141,9 @@ let server = {
 			item = new ItemStack(material);
 		}
 		item.setAmount(count);
+		if (durability !== undefined) {
+			item.setDurability(durability);
+		}
 		meta = item.getItemMeta();
 		if (name !== undefined) {
 			meta.setDisplayName(name);
@@ -153,9 +156,6 @@ let server = {
 				loreArray = lore;
 			}
 			meta.setLore(Arrays.asList(loreArray));
-		}
-		if (durability !== undefined) {
-			item.setDurability(durability);
 		}
 		if (unbreakable !== undefined) {
 			meta.setUnbreakable(unbreakable);


### PR DESCRIPTION
Took longer than I expected, but finally got this working. Changes:

- Added support for **CustomModelData** (int) and **ItemFlag** (string array)
- Fixed durability not being applied to an item

 Let me know if code style and practices are OK, so I can commit some changes in case there is something wrong with my implementation.

**SIDE-NOTE:** _I was thinking of replacing deprecated method `ItemStack#setDurability` with `Damageable#setDamage`, but that would break compatibility with older versions (I think this change was introduced in 1.13). You can read [this](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/inventory/ItemStack.html#setDurability(short)) for more details._