### PR TITLE
/velt eval

### DIFF
--- a/src/main/resources/velt.js
+++ b/src/main/resources/velt.js
@@ -778,6 +778,7 @@ const infoMsg = c`
 &8-----------
 &b/velt &8| &b/velt info &8| &b/velt help &8| &fGet info on how to use Velt
 &b/velt reload &8| &fReload all of your Velt scripts
+&b/velt eval &8| &fRun JavaScript ingame
 &8-----------`;
 
 
@@ -785,7 +786,14 @@ commands.create('velt', {
     subs: {
         info: () => infoMsg,
         help: () => infoMsg,
-        reload: () => c`&5&lVelt &8| &b/velt reload &fis not yet implemented.`
+        reload: () => c`&5&lVelt &8| &b/velt reload &fis not yet implemented.`,
+        eval: (sender, ...args) => {
+		if (!sender.hasPermission("velt.eval")) return;
+		const evaluate = args.join(' ');
+		sender.sendMessage(c`&5&lVelt &8| &b${evaluate}`)
+		try { sender.sendMessage(`${eval(evaluate)}`) } 
+		catch(error) { sender.sendMessage(c(`&c${error}`)) }
+        }
     },
     run: () => infoMsg
 });

--- a/src/main/resources/velt.js
+++ b/src/main/resources/velt.js
@@ -787,12 +787,16 @@ commands.create('velt', {
         info: () => infoMsg,
         help: () => infoMsg,
         reload: () => c`&5&lVelt &8| &b/velt reload &fis not yet implemented.`,
-        eval: (sender, ...args) => {
+        eval(sender, ...args) {
 		if (!sender.hasPermission("velt.eval")) return;
 		const evaluate = args.join(' ');
 		sender.sendMessage(c`&5&lVelt &8| &b${evaluate}`)
-		try { sender.sendMessage(`${eval(evaluate)}`) } 
-		catch(error) { sender.sendMessage(c(`&c${error}`)) }
+		try { 
+			sender.sendMessage(`${eval(evaluate)}`) 
+		} 
+		catch (error) { 
+			sender.sendMessage(c(`&c${error}`))
+		}
         }
     },
     run: () => infoMsg


### PR DESCRIPTION
This pull requests adds `/velt eval` to velt (requires perm `velt.eval`), which in my opinion, is a very useful debugging tool.
![image](https://user-images.githubusercontent.com/29683770/111926944-40f4ca80-8a85-11eb-9fbd-8ab56cfb52ce.png)
as you can see, anything works perfectly. This edits the current `/velt` command so anything imported in the `velt.js` module is accessible inside `/velt eval`, not to mention you can import in the eval with `Java.pkg`. The reason `null` is sent sometimes is because the player is sent the eval result directly, which means if there's no result (such as when a method is executed on the player), the result is `null`.