### PR TITLE
fix closing inventory

### DIFF
--- a/src/main/resources/velt/helpers.js
+++ b/src/main/resources/velt/helpers.js
@@ -156,7 +156,7 @@ class Gui {
 		this.callbacks[slot] = event => {
 			const out = run(event);
 			if (close) {
-				event.getWhoClicked().getInventory().closeInventory();
+				event.getWhoClicked().closeInventory();
 			}
 			return out;
 		};


### PR DESCRIPTION
Fixes closing inventory after Gui item is clicked:
```js
Gui#set(slot, item, {
  close: true
});
```