### PR TITLE
Separate Velt Runtime from Plugin

### DIFF
--- a/src/main/java/xyz/corman/velt/JSRuntime.java
+++ b/src/main/java/xyz/corman/velt/JSRuntime.java
@@ -1,6 +1,7 @@
 package xyz.corman.velt;
 import com.sun.org.apache.bcel.internal.generic.JSR;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
 
 import java.io.File;
 
@@ -25,16 +26,20 @@ public class JSRuntime {
         return this;
     }
 
+    public Value eval(String text, String path) {
+        return context.eval(Utils.fromString(text, path));
+    }
+
     public JSRuntime() {}
 
-    public void require(String module) {
-        context.eval(Utils.fromString(String.format("require('%s')", Utils.escape(module)), "Velt Runtime"));
+    public Value require(String module) {
+        return this.eval(String.format("require('%s')", Utils.escape(module)), "Velt Runtime");
     }
 
     public JSRuntime init() {
         context = ContextCreation.createContext();
         context.getBindings("js").putMember("__context", context);
-        context.getBindings("js").putMember("__jsruntime", this);
+        context.getBindings("js").putMember("__runtime", this);
         String loaderPath = String.join(File.separator, modulesFolder, "velt-loader", "index.js").trim();
         loaderPath = Utils.escape(loaderPath);
         context.eval(Utils.fromString("load('" + loaderPath + "')", "velt-loader.js"));

--- a/src/main/java/xyz/corman/velt/JSRuntime.java
+++ b/src/main/java/xyz/corman/velt/JSRuntime.java
@@ -1,0 +1,52 @@
+package xyz.corman.velt;
+import com.sun.org.apache.bcel.internal.generic.JSR;
+import org.graalvm.polyglot.Context;
+
+import java.io.File;
+
+public class JSRuntime {
+    Context context;
+    private boolean provideGlobals;
+    private String modulesFolder;
+    private String scriptsFolder;
+
+    public String getScriptsFolder() {
+        return scriptsFolder;
+    }
+    public void setScriptsFolder(String scriptsFolder) {
+        this.scriptsFolder = scriptsFolder;
+    }
+
+    public boolean getProvideGlobals() {
+        return provideGlobals;
+    }
+    public JSRuntime setProvideGlobals(boolean provideGlobals) {
+        this.provideGlobals = provideGlobals;
+        return this;
+    }
+
+    public String getModulesFolder() {
+        return modulesFolder;
+    }
+    public JSRuntime setModulesFolder(String modulesFolder) {
+        this.modulesFolder = modulesFolder;
+        return this;
+    }
+
+    public JSRuntime() {
+        context = ContextCreation.createContext();
+    }
+
+    public void require(String module) {
+        context.eval(Utils.fromString(String.format("require('%s')", module), "Velt Runtime"));
+    }
+
+    public JSRuntime init() {
+        context.getBindings("js").putMember("__context", context);
+        String loaderPath = String.join(File.separator, modulesFolder, "velt-loader", "index.js").trim();
+        loaderPath = Utils.escape(loaderPath);
+        context.eval(Utils.fromString("load('" + loaderPath + "')", "velt-loader.js"));
+        require("globals");
+        return this;
+    }
+}

--- a/src/main/java/xyz/corman/velt/Runtime.java
+++ b/src/main/java/xyz/corman/velt/Runtime.java
@@ -1,5 +1,0 @@
-package xyz.corman.velt;
-
-public class Runtime {
-
-}

--- a/src/main/java/xyz/corman/velt/Runtime.java
+++ b/src/main/java/xyz/corman/velt/Runtime.java
@@ -1,0 +1,5 @@
+package xyz.corman.velt;
+
+public class Runtime {
+
+}

--- a/src/main/java/xyz/corman/velt/Utils.java
+++ b/src/main/java/xyz/corman/velt/Utils.java
@@ -26,6 +26,7 @@ import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.SimplePluginManager;
 import org.bukkit.util.Vector;
 import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
 
 import xyz.corman.velt.Velt.ContextCallback;
@@ -159,5 +160,9 @@ public class Utils {
 			Bukkit.getScheduler().scheduleSyncDelayedTask(Velt.getInstance(), val::execute, 0); //why does this need to be delayed by 1 tick?
 		});
 		return res;
+	}
+
+	public static Source fromString(String string, String path) {
+		return Source.newBuilder("js", string, path).buildLiteral();
 	}
 }

--- a/src/main/java/xyz/corman/velt/Velt.java
+++ b/src/main/java/xyz/corman/velt/Velt.java
@@ -404,7 +404,7 @@ public class Velt extends JavaPlugin implements Listener {
 			}
 		}
 		try {
-			context.eval(fromString("throw new Error()", "<error>"));
+			context.eval(Utils.fromString("throw new Error()", "<error>"));
 		} catch (Exception e) {}
 		Context current = context;
 		Bukkit.getScheduler().scheduleSyncDelayedTask(this, () -> {
@@ -424,10 +424,10 @@ public class Velt extends JavaPlugin implements Listener {
 			String loaderPath = String.join(File.separator, dataFolder.getAbsolutePath(), "node_modules", "velt-loader", "index.js")
 					.trim();
 			loaderPath = Utils.escape(loaderPath);
-			context.eval(fromString("load('" + loaderPath + "')", "velt-loader.js"));
+			context.eval(Utils.fromString("load('" + loaderPath + "')", "velt-loader.js"));
 			log.info("Loading scripts");
-			context.eval(fromString("require('globals')", "globals.js"));
-			context.eval(fromString("require('velt/setup')", "globals.js"));
+			context.eval(Utils.fromString("require('globals')", "globals.js"));
+			context.eval(Utils.fromString("require('velt/setup')", "globals.js"));
 			for (File file : Objects.requireNonNull(scriptsFolder.listFiles())) {
 				String path = file.getAbsolutePath();
 				String fileName = file.getPath();
@@ -443,11 +443,8 @@ public class Velt extends JavaPlugin implements Listener {
 				}
 				log.info(String.format("Loading script: %s", file.getName()));
 				String absPath = Utils.escape(file.getAbsolutePath().trim());
-				context.eval(fromString("require('" + absPath + "')", "<Loading>"));
+				context.eval(Utils.fromString("require('" + absPath + "')", "<Loading>"));
 			}
 		});
-	}
-	public static Source fromString(String string, String path) {
-		return Source.newBuilder("js", string, path).buildLiteral();
 	}
 }

--- a/src/main/java/xyz/corman/velt/Velt.java
+++ b/src/main/java/xyz/corman/velt/Velt.java
@@ -360,6 +360,10 @@ public class Velt extends JavaPlugin implements Listener {
 		Bukkit.getScheduler().scheduleSyncDelayedTask(this, this::load, 1);
 		
 		loadBStats();
+
+		runtime = new VeltRuntime();
+		runtime.setModulesFolder(modulesFolder.getAbsolutePath());
+		runtime.setProvideGlobals(true);
 	}
 	public void reload(AnonymousCallback<Throwable> callback) {
 		Velt velt = this;
@@ -406,8 +410,7 @@ public class Velt extends JavaPlugin implements Listener {
 	}
 	public void load() {
 		Utils.runInPluginContext(() -> {
-			runtime.init();
-			runtime.require("velt/setup");
+			runtime.clearScripts();
 			for (File file : Objects.requireNonNull(scriptsFolder.listFiles())) {
 				String path = file.getAbsolutePath();
 				String fileName = file.getPath();
@@ -423,8 +426,10 @@ public class Velt extends JavaPlugin implements Listener {
 				}
 				log.info(String.format("Loading script: %s", file.getName()));
 				String absPath = Utils.escape(file.getAbsolutePath().trim());
-				runtime.require(absPath);
+				runtime.addScript(absPath);
 			}
+			runtime.init();
+			runtime.require("velt/setup");
 		});
 	}
 }

--- a/src/main/java/xyz/corman/velt/VeltRuntime.java
+++ b/src/main/java/xyz/corman/velt/VeltRuntime.java
@@ -3,7 +3,7 @@ package xyz.corman.velt;
 import java.util.ArrayList;
 
 public class VeltRuntime extends JSRuntime {
-    ArrayList<String> scripts;
+    private ArrayList<String> scripts;
     public VeltRuntime() {
         super();
         scripts = new ArrayList<>();
@@ -11,6 +11,11 @@ public class VeltRuntime extends JSRuntime {
 
     public VeltRuntime addScript(String script) {
         scripts.add(script);
+        return this;
+    }
+
+    public VeltRuntime clearScripts() {
+        scripts.clear();
         return this;
     }
 

--- a/src/main/java/xyz/corman/velt/VeltRuntime.java
+++ b/src/main/java/xyz/corman/velt/VeltRuntime.java
@@ -1,0 +1,30 @@
+package xyz.corman.velt;
+
+import java.util.ArrayList;
+
+public class VeltRuntime extends JSRuntime {
+    ArrayList<String> scripts;
+    public VeltRuntime() {
+        super();
+        scripts = new ArrayList<>();
+    }
+
+    public VeltRuntime addScript(String script) {
+        scripts.add(script);
+        return this;
+    }
+
+    @Override
+    public VeltRuntime init() {
+        super.init();
+        for (String script : scripts) {
+            super.require(script);
+        }
+        return this;
+    }
+
+    public VeltRuntime stop() {
+        super.stop();
+        return this;
+    }
+}

--- a/src/main/resources/velt-loader/index.js
+++ b/src/main/resources/velt-loader/index.js
@@ -158,8 +158,10 @@ require = (function() {
 
 		if (!fileExists(filename)) { //Resolve as a node module, either a core or regular module
 			if (level == 0) {
-				const modules = Paths.get(Velt.getInstance().getDataFolder().getAbsolutePath().toString(), "node_modules", id).toString();
-				const coreModules = Paths.get(Velt.getInstance().getDataFolder().getAbsolutePath().toString(), "node_modules", "core", id).toString();
+				/*const modules = Paths.get(Velt.getInstance().getDataFolder().getAbsolutePath().toString(), "node_modules", id).toString();
+				const coreModules = Paths.get(Velt.getInstance().getDataFolder().getAbsolutePath().toString(), "node_modules", "core", id).toString();*/
+				const modules = Paths.get(__runtime.getModulesFolder(), id).toString();
+				const coreModules = Paths.get(__runtime.getModulesFolder(), id).toString();
 				let res = require(modules, parent, 1);
 				if (res === Failure) res = require(coreModules, parent, 1);
 				return res;

--- a/src/main/resources/velt-loader/index.js
+++ b/src/main/resources/velt-loader/index.js
@@ -163,10 +163,10 @@ require = (function() {
 				const modules = Paths.get(__runtime.getModulesFolder(), id).toString();
 				const coreModules = Paths.get(__runtime.getModulesFolder(), id).toString();
 				let res = require(modules, parent, 1);
-				if (res === Failure) res = require(coreModules, parent, 1);
+				if (res === null) res = require(coreModules, parent, 1);
 				return res;
 			} else {
-				return Failure;
+				return null;
 			}
 		}
 

--- a/src/main/resources/velt-loader/index.js
+++ b/src/main/resources/velt-loader/index.js
@@ -121,7 +121,7 @@ require = (function() {
 					 Object.defineProperty(func, 'name', {value: name, configurable: true});
 					 func.apply(module, [ module.exports, module, id => require(id, module), module.filename, module.path ]);*/
 					const source = `(function(exports, module, require, __filename, __dirname) {${this.body}\n})`;
-					const evaluated = __context.eval(Velt.fromString(source, module.filename));
+					const evaluated = __runtime.eval(source, module.filename);
 					evaluated.apply(module, [module.exports, module, id => require(id, module), module.filename, module.path]);
 				} catch (e) {
 					console.error(`Error in ${this.filename}`);
@@ -161,7 +161,7 @@ require = (function() {
 				/*const modules = Paths.get(Velt.getInstance().getDataFolder().getAbsolutePath().toString(), "node_modules", id).toString();
 				const coreModules = Paths.get(Velt.getInstance().getDataFolder().getAbsolutePath().toString(), "node_modules", "core", id).toString();*/
 				const modules = Paths.get(__runtime.getModulesFolder(), id).toString();
-				const coreModules = Paths.get(__runtime.getModulesFolder(), id).toString();
+				const coreModules = Paths.get(__runtime.getModulesFolder(), 'core', id).toString();
 				let res = require(modules, parent, 1);
 				if (res === null) res = require(coreModules, parent, 1);
 				return res;


### PR DESCRIPTION
This is a new PR for separating the Velt runtime (running code, loading require, etc) from the rest of Velt. There's two reasons we want to do this:

- Make it so the TypeScript compiler only loads once
- More importantly, make it so Velt can be used with **bungeecord** and **velocity**.

That's all, thanks!